### PR TITLE
複数チャネル対応

### DIFF
--- a/android/src/main/kotlin/com/linecorp/flutter_line_sdk/LineSdkWrapper.kt
+++ b/android/src/main/kotlin/com/linecorp/flutter_line_sdk/LineSdkWrapper.kt
@@ -40,7 +40,7 @@ class LineSdkWrapper {
     fun setupSdk(activity: Activity, channelId: String) {
         runIfDebugBuild {  Log.d(TAG, "setupSdk") }
 
-        if (!this::channelId.isInitialized) {
+        if (!this::channelId.isInitialized || this.channelId != channelId) { // 異なるチャンネルによる再初期化を有効にするため
             this.channelId = channelId
         }
 

--- a/ios/Classes/SwiftFlutterLineSdkPlugin.swift
+++ b/ios/Classes/SwiftFlutterLineSdkPlugin.swift
@@ -101,10 +101,11 @@ extension LineChannelMethod {
 
   func setup(arguments: [String: Any]?, result: @escaping FlutterResult) {
     
-    guard !LoginManager.shared.isSetupFinished else {
-        result(nil)
-        return
-    }
+   // 異なるチャンネルによる再初期化を有効にするため
+    // guard !LoginManager.shared.isSetupFinished else {
+    //     result(nil)
+    //     return
+    // }
 
     guard let args = arguments else {
       result(FlutterError.nilArgument)


### PR DESCRIPTION
atohamaのUUUOテナントでのLINE ID連携は、以下の問題が発生するため実現できていませんでした。
- atohamaでLINEログイン→UUUOテナントに切り替えてLINE連携→atohamaのLINE公式アカウントが表示される（期待する結果はUUUOのLINE公式アカウントの表示）

これが起きる原因は、LineSDK.instance.setupが一度行われると再起動等が起こらない限り再度setupはできないようにSDK側で実装されているためでした。
それを今回修正してsetupが複数回できるようにすることで、複数のチャネルに対応できるようにしました。
